### PR TITLE
refactor: migrate web plugin from js_interop_unsafe to typed JS interop bindings

### DIFF
--- a/lib/src/experiment_web_plugin.dart
+++ b/lib/src/experiment_web_plugin.dart
@@ -1,5 +1,4 @@
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'dart:async';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:amplitude_experiment/src/experiment_platform_interface.dart';
@@ -9,6 +8,7 @@ import 'package:amplitude_experiment/src/web/codec/config_codec.dart';
 import 'package:amplitude_experiment/src/web/codec/user_codec.dart';
 import 'package:amplitude_experiment/src/web/codec/variant_codec.dart';
 import 'package:amplitude_experiment/src/web/codec/options_codec.dart';
+import 'package:amplitude_experiment/src/web/codec/codec_utils.dart';
 import 'package:amplitude_experiment/src/experiment_config.dart';
 import 'package:amplitude_experiment/src/providers.dart'
     show ExposureTrackingProvider;
@@ -106,28 +106,25 @@ class ExperimentWebPlugin extends ExperimentPlatform {
     ExperimentUser? user,
   ) async {
     final client = _getClient(instanceName);
-    final allFn = client['all'] as JSFunction?;
-    if (allFn == null) {
-      throw UnsupportedError('Client.all not found');
+    final allVariants = client.all();
+    final dartified = allVariants.dartify();
+    if (dartified == null) {
+      return {};
     }
 
-    final allVariants =
-        allFn.callAsFunction(client, <JSAny>[].toJS) as JSObject;
+    final allMap = CodecUtils.toPlainMap(dartified);
+    if (allMap == null) {
+      return {};
+    }
+
     final Map<String, Variant> result = {};
-
-    // Get all keys from the JS object using Object.keys
-    final objectKeys = globalContext['Object'] as JSObject;
-    final keysFn = objectKeys['keys'] as JSFunction;
-    final keys =
-        keysFn.callAsFunction(objectKeys, [allVariants].toJS)
-            as JSArray<JSString>;
-
-    for (var i = 0; i < keys.length; i++) {
-      final key = keys[i];
-      final keyStr = key.toDart;
-      final variantObj = allVariants[keyStr] as JSObject?;
-      if (variantObj != null) {
-        result[keyStr] = VariantCodec.fromJSObject(variantObj);
+    for (final entry in allMap.entries) {
+      final variantRaw = entry.value;
+      if (variantRaw != null) {
+        final variantMap = CodecUtils.toPlainMap(variantRaw);
+        if (variantMap != null) {
+          result[entry.key] = VariantCodec.fromMap(variantMap);
+        }
       }
     }
 
@@ -137,11 +134,7 @@ class ExperimentWebPlugin extends ExperimentPlatform {
   @override
   Future<void> clear(String instanceName) async {
     final client = _getClient(instanceName);
-    final clearFn = client['clear'] as JSFunction?;
-    if (clearFn == null) {
-      throw UnsupportedError('Client.clear not found');
-    }
-    clearFn.callAsFunction(client, <JSAny>[].toJS);
+    client.clear();
   }
 
   @override
@@ -153,30 +146,15 @@ class ExperimentWebPlugin extends ExperimentPlatform {
   @override
   Future<ExperimentUser> getUser(String instanceName) async {
     final client = _getClient(instanceName);
-    final getUserFn = client['getUser'] as JSFunction?;
-    if (getUserFn == null) {
-      throw UnsupportedError('Client.getUser not found');
-    }
-
-    final userObj =
-        getUserFn.callAsFunction(client, <JSAny>[].toJS) as JSObject?;
-
-    if (userObj == null) {
-      return ExperimentUser();
-    }
-
+    final userObj = client.getUser();
     return UserCodec.fromJSObject(userObj);
   }
 
   @override
   Future<void> setUser(String instanceName, ExperimentUser user) async {
     final client = _getClient(instanceName);
-    final setUserFn = client['setUser'] as JSFunction?;
-    if (setUserFn == null) {
-      throw UnsupportedError('Client.setUser not found');
-    }
     final userObj = UserCodec.toJSObject(user);
-    setUserFn.callAsFunction(client, [userObj].toJS);
+    client.setUser(userObj);
   }
 
   @override
@@ -185,11 +163,7 @@ class ExperimentWebPlugin extends ExperimentPlatform {
     bool tracksAssignment,
   ) async {
     final client = _getClient(instanceName);
-    final setTracksAssignmentFn = client['setTracksAssignment'] as JSFunction?;
-    if (setTracksAssignmentFn == null) {
-      throw UnsupportedError('Client.setTracksAssignment not found');
-    }
-    setTracksAssignmentFn.callAsFunction(client, [tracksAssignment.toJS].toJS);
+    client.setTracksAssignment(tracksAssignment);
   }
 
   /// No-op on web. Tracking providers are wired through the config at init

--- a/lib/src/web/codec/config_codec.dart
+++ b/lib/src/web/codec/config_codec.dart
@@ -1,5 +1,4 @@
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'package:amplitude_experiment/src/generated/amplitude_experiment_api.g.dart';
 import 'package:amplitude_experiment/src/experiment_config.dart';
 import 'package:amplitude_experiment/src/providers.dart';
@@ -7,15 +6,12 @@ import 'package:amplitude_experiment/src/pigeon_mappers.dart';
 import 'package:amplitude_experiment/src/web/codec/exposure_codec.dart';
 import 'package:amplitude_experiment/src/web/codec/user_codec.dart';
 import 'package:amplitude_experiment/src/web/codec/variant_codec.dart';
+import 'package:amplitude_experiment/src/web/experiment_js.dart';
 
 /// Codec for converting ExperimentConfig between Dart and JS objects.
 class ConfigCodec {
   /// Converts an ExperimentConfig to a JSObject for the JavaScript SDK.
-  static JSObject toJSObject(
-    ExperimentConfig c,
-    // ExposureTrackingProvider? trackingProvider,
-    // UserProvider? userProvider,
-  ) {
+  static JSObject toJSObject(ExperimentConfig c) {
     final config = c.pigeonConfig;
 
     final configMap = <String, dynamic>{
@@ -68,34 +64,36 @@ class ConfigCodec {
         break;
     }
 
-    final configObj = configMap.jsify() as JSObject;
+    final configObj = configMap.jsify() as JSExperimentConfig;
     if (c.trackingProvider != null) {
-      configObj['exposureTrackingProvider'] = _buildTrackingProviderJS(
+      configObj.exposureTrackingProvider = _buildTrackingProviderJS(
         c.trackingProvider!,
       );
     }
     if (c.userProvider != null) {
-      configObj['userProvider'] = _buildUserProviderJS(c.userProvider!);
+      configObj.userProvider = _buildUserProviderJS(c.userProvider!);
     }
 
     return configObj;
   }
 
-  static JSObject _buildTrackingProviderJS(ExposureTrackingProvider provider) {
-    final obj = <String, dynamic>{}.jsify() as JSObject;
-    obj['track'] = ((JSObject jsExposure) {
-      final pigeonExposure = ExposureCodec.fromJSObject(jsExposure);
-      provider.track(exposureFromPigeon(pigeonExposure));
-    }).toJS;
-    return obj;
+  static JSExposureTrackingProvider _buildTrackingProviderJS(
+    ExposureTrackingProvider provider,
+  ) {
+    return JSExposureTrackingProvider(
+      track: ((JSObject jsExposure) {
+        final pigeonExposure = ExposureCodec.fromJSObject(jsExposure);
+        provider.track(exposureFromPigeon(pigeonExposure));
+      }).toJS,
+    );
   }
 
-  static JSObject _buildUserProviderJS(UserProvider provider) {
-    final obj = <String, dynamic>{}.jsify() as JSObject;
-    obj['getUser'] = (() {
-      final user = provider.getUser();
-      return UserCodec.toJSObject(user.toPigeon());
-    }).toJS;
-    return obj;
+  static JSUserProvider _buildUserProviderJS(UserProvider provider) {
+    return JSUserProvider(
+      getUser: (() {
+        final user = provider.getUser();
+        return UserCodec.toJSObject(user.toPigeon());
+      }).toJS,
+    );
   }
 }

--- a/lib/src/web/codec/variant_codec.dart
+++ b/lib/src/web/codec/variant_codec.dart
@@ -28,12 +28,16 @@ class VariantCodec {
       return Variant();
     }
 
-    // Normalize to a plain Map (dartify() can return IdentityMap, etc.)
     final variantMap = CodecUtils.toPlainMap(dartified);
     if (variantMap == null) {
       return Variant();
     }
 
+    return fromMap(variantMap);
+  }
+
+  /// Converts a plain Dart Map to a Variant.
+  static Variant fromMap(Map<String, dynamic> variantMap) {
     final key = variantMap['key'];
     final value = variantMap['value'];
     final payload = variantMap['payload'];

--- a/lib/src/web/experiment_js.dart
+++ b/lib/src/web/experiment_js.dart
@@ -1,10 +1,7 @@
 import 'dart:js_interop';
 
 @JS('Experiment')
-@staticInterop
-class Experiment {
-  external factory Experiment._();
-
+extension type Experiment._(JSObject _) implements JSObject {
   external static ExperimentClient initialize(String apiKey, JSObject? config);
   external static ExperimentClient initializeWithAmplitudeAnalytics(
     String apiKey,
@@ -40,4 +37,23 @@ extension type ExperimentClient(JSObject _) implements JSObject {
 
   // setUser(user: ExperimentUser): void
   external void setUser(JSObject user);
+
+  // setTracksAssignment(tracksAssignment: boolean): void
+  external void setTracksAssignment(bool tracksAssignment);
+}
+
+@JS('Object.keys')
+external JSArray<JSString> objectKeys(JSObject o);
+
+extension type JSExposureTrackingProvider._(JSObject _) implements JSObject {
+  external factory JSExposureTrackingProvider({JSFunction track});
+}
+
+extension type JSUserProvider._(JSObject _) implements JSObject {
+  external factory JSUserProvider({JSFunction getUser});
+}
+
+extension type JSExperimentConfig._(JSObject _) implements JSObject {
+  external set exposureTrackingProvider(JSExposureTrackingProvider? value);
+  external set userProvider(JSUserProvider? value);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplitude_experiment
 description: "The official Amplitude Experiment Flutter SDK"
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.2
 homepage: "https://github.com/amplitude/experiment-flutter-client"
 
 environment:


### PR DESCRIPTION
### Summary

Replace all dart:js_interop_unsafe bracket-access patterns with typed
extension type declarations. This eliminates fragile runtime method
lookups in favor of compile-time checked external member bindings.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
