### PR TITLE
fix: relax Dart SDK constraint from ^3.10.3 to ^3.8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,33 +1,13 @@
 group = "com.amplitude.experiment.flutter"
 version = "0.1.0-beta.1" // x-release-please-version
 
-buildscript {
-    ext.kotlin_version = "2.2.20"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.11.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
     namespace = "com.amplitude.experiment.flutter"
 
-    compileSdk = 36
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: "Demonstrates how to use the experiment_flutter plugin."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ^3.10.3
+  sdk: ^3.8.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0-beta.1 # x-release-please-version
 homepage: "https://github.com/amplitude/experiment-flutter-client"
 
 environment:
-  sdk: ^3.10.3
+  sdk: ^3.8.0
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
## Summary

- Relax `sdk` constraint in `pubspec.yaml` from `^3.10.3` to `^3.8.0`
- Remove `buildscript` and `allprojects` blocks from `android/build.gradle` (host project manages Kotlin/Gradle versions)
- Lower `compileSdk` from `36` to `35` for broader compatibility

## Motivation

The Dart code in this package uses no language features beyond Dart 3.3:

- `extension type` (Dart 3.3) in `lib/src/web/experiment_js.dart`
- `.indexed` on `List` (Dart 3.0) in the Pigeon-generated file
- Record types `(int, dynamic)` (Dart 3.0) in the Pigeon-generated file

The `^3.10.3` constraint was likely set to match the local SDK version when Pigeon codegen was run, not because any language feature requires it. This unnecessarily prevents adoption by projects on Flutter 3.35.x (Dart 3.9.x), which is the current stable channel for many production apps.

We verified all library code compiles and runs correctly on Dart 3.9.2 (Flutter 3.35.6).

## Android build.gradle changes

The `buildscript` block declared Kotlin 2.2.20 and Gradle 8.11.1, which can conflict with host projects using different versions. In Flutter's plugin architecture, the host project's `settings.gradle.kts` manages these. Removing the block avoids version conflicts without affecting functionality.

`compileSdk` was lowered from 36 to 35 since API 35 is the current stable Android SDK level.

## Test plan

- [x] Verified all Dart language features used compile on Dart 3.9.2
- [x] `extension type`, `.indexed`, and record destructuring confirmed working
- [x] No `dart:` imports require SDK 3.10+

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily build-configuration changes (Dart SDK constraints and Android Gradle settings) with low runtime risk, though it may affect consumers if their builds relied on the plugin-defined Kotlin/Gradle versions or API 36 features.
> 
> **Overview**
> Relaxes the Dart SDK constraint from `^3.10.3` to `^3.8.0` in both the root `pubspec.yaml` and the example app to allow use on older Flutter/Dart toolchains.
> 
> On Android, removes the plugin-level `buildscript`/`allprojects` repository and tooling version declarations so the host app controls Gradle/Kotlin versions, and lowers `compileSdk` from `36` to `35` for broader Android SDK compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90f62fc89cb35dbee4ed3359f2d4305f0f0df39d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->