### PR TITLE
chore: use pull_request vs pull_request_target in release scripts

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,7 +1,7 @@
 name: Semantic PR Check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, edited]
 
 permissions:


### PR DESCRIPTION
<!---
Thanks for contributing to the Experimnt Flutter SDK repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Uses `pull_request` vs `pull_request_target` in semantic pr check

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-flutter-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change that only affects when the PR title validation workflow runs; it doesn’t touch application code or release artifacts.
> 
> **Overview**
> Updates the `Semantic PR Check` GitHub Action to trigger on the `pull_request` event instead of `pull_request_target`, changing the security context/permissions used when validating PR titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b11c58f07daf71585de461535e4d05b86153fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->