### PR TITLE
fix: honor serverZone:EU on Flutter (Android + Web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ All config fields have sensible defaults. Common options:
 | `automaticExposureTracking` | `true` | Track exposures on `variant()` calls |
 | `fetchOnStart` | `true` | Fetch flags when `start()` is called |
 
+### EU data residency
+
+To send traffic to Amplitude's EU servers, set `serverZone` to `ServerZone.eu`:
+
+```dart
+final config = ExperimentConfig(serverZone: ServerZone.eu);
+```
+
+That is all that is required: the SDK automatically routes to the EU hosts
+(`api.lab.eu.amplitude.com` and `flag.lab.eu.amplitude.com`). Only set
+`serverUrl` / `flagsServerUrl` when you need a custom proxy host; doing so
+overrides the automatic `serverZone` routing.
+
 See `ExperimentConfig` API docs for the full list.
 
 ## Learn More

--- a/android/src/main/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodec.kt
+++ b/android/src/main/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodec.kt
@@ -73,8 +73,16 @@ fun convertConfig(flutterConfig: FlutterConfig, api: CustomProviderApi): Experim
     builder.initialVariants(variantsFromPigeon(flutterConfig.initialVariants))
     builder.source(parseSource(flutterConfig.source))
     builder.serverZone(parseServerZone(flutterConfig.serverZone))
-    builder.serverUrl(flutterConfig.serverUrl)
-    builder.flagsServerUrl(flutterConfig.flagsServerUrl)
+    // Only forward explicitly-overridden URLs. An empty value is the sentinel
+    // for "left at the Flutter default", in which case we let the native SDK
+    // resolve the host from serverZone (so serverZone == EU routes to the EU
+    // host instead of being silently overridden by the forwarded US default).
+    if (flutterConfig.serverUrl.isNotEmpty()) {
+        builder.serverUrl(flutterConfig.serverUrl)
+    }
+    if (flutterConfig.flagsServerUrl.isNotEmpty()) {
+        builder.flagsServerUrl(flutterConfig.flagsServerUrl)
+    }
     builder.fetchTimeoutMillis(flutterConfig.fetchTimeoutMillis)
     builder.retryFetchOnFailure(flutterConfig.retryFetchOnFailure)
     builder.automaticExposureTracking(flutterConfig.automaticExposureTracking)

--- a/android/src/test/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodecTest.kt
+++ b/android/src/test/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodecTest.kt
@@ -213,6 +213,38 @@ internal class ExperimentSdkCodecTest {
         assertEquals(0, sdk.initialVariants.size)
     }
 
+    @Test
+    fun convertConfig_emptyServerUrls_keepNativeDefaultsForServerZoneResolution() {
+        // An empty URL is the sentinel for "left at the Flutter default". The
+        // codec must NOT forward it; otherwise it overrides the native default
+        // and defeats the native serverZone -> host resolution (EU support).
+        val baseline = com.amplitude.experiment.ExperimentConfig.builder()
+            .serverZone(SdkServerZone.EU)
+            .build()
+        val pigeon = TestDataHelpers.createPigeonConfig(
+            serverZone = ServerZone.EU,
+            serverUrl = "",
+            flagsServerUrl = "",
+        )
+        val sdk = convertConfig(pigeon, mockApi)
+        assertEquals(SdkServerZone.EU, sdk.serverZone)
+        // URLs untouched => identical to a config built without explicit URLs,
+        // so the native client applies the EU host.
+        assertEquals(baseline.serverUrl, sdk.serverUrl)
+        assertEquals(baseline.flagsServerUrl, sdk.flagsServerUrl)
+    }
+
+    @Test
+    fun convertConfig_explicitServerUrls_areForwarded() {
+        val pigeon = TestDataHelpers.createPigeonConfig(
+            serverUrl = "https://proxy.example.com",
+            flagsServerUrl = "https://flags.proxy.example.com",
+        )
+        val sdk = convertConfig(pigeon, mockApi)
+        assertEquals("https://proxy.example.com", sdk.serverUrl)
+        assertEquals("https://flags.proxy.example.com", sdk.flagsServerUrl)
+    }
+
     // ---------- convertFetchOptions ----------
 
     @Test

--- a/example/ios/RunnerTests/ExperimentSdkCodecTest.swift
+++ b/example/ios/RunnerTests/ExperimentSdkCodecTest.swift
@@ -195,6 +195,36 @@ class ExperimentSdkCodecTest: XCTestCase {
         XCTAssertEqual(sdk.initialVariants.count, 0)
     }
 
+    func testConvertConfig_emptyServerUrls_keepNativeDefaultsForServerZoneResolution() {
+        // An empty URL is the sentinel for "left at the Flutter default". The
+        // codec must NOT forward it; otherwise it overrides the native default
+        // and defeats the native serverZone -> host resolution (EU support).
+        let baselineBuilder = AmplitudeExperiment.ExperimentConfigBuilder()
+        baselineBuilder.serverZone(AmplitudeExperiment.ServerZone.EU)
+        let baseline = baselineBuilder.build()
+        let pigeon = TestDataHelpers.createPigeonConfig(
+            serverZone: .eu,
+            serverUrl: "",
+            flagsServerUrl: ""
+        )
+        let sdk = ExperimentSdkCodec.convertConfig(pigeon, api: TestDataHelpers.createMockProviderApi())
+        XCTAssertEqual(sdk.serverZone, AmplitudeExperiment.ServerZone.EU)
+        // URLs untouched => identical to a config built without explicit URLs,
+        // so the native client applies the EU host.
+        XCTAssertEqual(sdk.serverUrl, baseline.serverUrl)
+        XCTAssertEqual(sdk.flagsServerUrl, baseline.flagsServerUrl)
+    }
+
+    func testConvertConfig_explicitServerUrls_areForwarded() {
+        let pigeon = TestDataHelpers.createPigeonConfig(
+            serverUrl: "https://proxy.example.com",
+            flagsServerUrl: "https://flags.proxy.example.com"
+        )
+        let sdk = ExperimentSdkCodec.convertConfig(pigeon, api: TestDataHelpers.createMockProviderApi())
+        XCTAssertEqual(sdk.serverUrl, "https://proxy.example.com")
+        XCTAssertEqual(sdk.flagsServerUrl, "https://flags.proxy.example.com")
+    }
+
     // MARK: - convertFetchOptions
 
     func testConvertFetchOptions_nil_returnsNil() {

--- a/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
+++ b/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
@@ -86,8 +86,16 @@ enum ExperimentSdkCodec {
         builder.initialVariants(convertVariants(pigeon.initialVariants))
         builder.source(convertSource(pigeon.source))
         builder.serverZone(convertServerZone(pigeon.serverZone))
-        builder.serverUrl(pigeon.serverUrl)
-        builder.flagsServerUrl(pigeon.flagsServerUrl)
+        // Only forward explicitly-overridden URLs. An empty value is the
+        // sentinel for "left at the Flutter default", in which case the native
+        // SDK resolves the host from serverZone (so serverZone == .eu routes to
+        // the EU host instead of the forwarded US default).
+        if !pigeon.serverUrl.isEmpty {
+            builder.serverUrl(pigeon.serverUrl)
+        }
+        if !pigeon.flagsServerUrl.isEmpty {
+            builder.flagsServerUrl(pigeon.flagsServerUrl)
+        }
         builder.fetchTimeoutMillis(Int(pigeon.fetchTimeoutMillis))
         builder.fetchRetryOnFailure(pigeon.retryFetchOnFailure)
         builder.automaticExposureTracking(pigeon.automaticExposureTracking)

--- a/lib/src/experiment_config.dart
+++ b/lib/src/experiment_config.dart
@@ -76,10 +76,34 @@ class ExperimentConfig {
   final ServerZone serverZone;
 
   /// The server URL for remote evaluation.
+  ///
+  /// Defaults to [ExperimentConfigDefaults.serverUrl]. When left at the
+  /// default, the URL is NOT forwarded across the platform bridge so each
+  /// native SDK resolves the correct host from [serverZone] (e.g. the EU
+  /// host for [ServerZone.eu]). See [_serverUrlExplicitlySet].
   final String serverUrl;
 
   /// The server URL for local evaluation flag data.
+  ///
+  /// Defaults to [ExperimentConfigDefaults.flagsServerUrl]. When left at the
+  /// default, the URL is NOT forwarded across the platform bridge so each
+  /// native SDK resolves the correct host from [serverZone]. See
+  /// [_flagsServerUrlExplicitlySet].
   final String flagsServerUrl;
+
+  /// Whether [serverUrl] was explicitly provided by the caller.
+  ///
+  /// When `false`, the default URL is intentionally withheld from the native
+  /// bridge so the native SDK applies its own [serverZone] -> host routing.
+  /// Forwarding the Dart default (which lacks a trailing slash) would
+  /// otherwise defeat the native EU override and silently route EU traffic to
+  /// the US host.
+  final bool _serverUrlExplicitlySet;
+
+  /// Whether [flagsServerUrl] was explicitly provided by the caller.
+  ///
+  /// See [_serverUrlExplicitlySet] for the rationale.
+  final bool _flagsServerUrlExplicitlySet;
 
   /// The fetch timeout in milliseconds.
   final int fetchTimeoutMillis;
@@ -116,8 +140,8 @@ class ExperimentConfig {
     this.initialVariants = ExperimentConfigDefaults.initialVariants,
     this.source = ExperimentConfigDefaults.source,
     this.serverZone = ExperimentConfigDefaults.serverZone,
-    this.serverUrl = ExperimentConfigDefaults.serverUrl,
-    this.flagsServerUrl = ExperimentConfigDefaults.flagsServerUrl,
+    String? serverUrl,
+    String? flagsServerUrl,
     this.fetchTimeoutMillis = ExperimentConfigDefaults.fetchTimeoutMillis,
     this.retryFetchOnFailure = ExperimentConfigDefaults.retryFetchOnFailure,
     this.automaticExposureTracking =
@@ -128,7 +152,11 @@ class ExperimentConfig {
         ExperimentConfigDefaults.automaticFetchOnAmplitudeIdentityChange,
     this.trackingProvider,
     this.userProvider,
-  });
+  }) : serverUrl = serverUrl ?? ExperimentConfigDefaults.serverUrl,
+       flagsServerUrl =
+           flagsServerUrl ?? ExperimentConfigDefaults.flagsServerUrl,
+       _serverUrlExplicitlySet = serverUrl != null,
+       _flagsServerUrlExplicitlySet = flagsServerUrl != null;
 
   pigeon.ExperimentConfigData get pigeonConfig {
     return pigeon.ExperimentConfigData(
@@ -136,12 +164,14 @@ class ExperimentConfig {
       logLevel: logLevelToPigeon(logLevel),
       fallbackVariant: fallbackVariant?.toPigeon() ?? pigeon.Variant(),
       initialFlags: initialFlags,
-      initialVariants:
-          initialVariants.map((k, v) => MapEntry(k, v.toPigeon())),
+      initialVariants: initialVariants.map((k, v) => MapEntry(k, v.toPigeon())),
       source: sourceToPigeon(source),
       serverZone: serverZoneToPigeon(serverZone),
-      serverUrl: serverUrl,
-      flagsServerUrl: flagsServerUrl,
+      // Forward an empty sentinel when the URL was left at its default so the
+      // native SDK resolves the host from serverZone. Only forward an explicit
+      // override. This keeps serverZone == EU routing to the EU host.
+      serverUrl: _serverUrlExplicitlySet ? serverUrl : '',
+      flagsServerUrl: _flagsServerUrlExplicitlySet ? flagsServerUrl : '',
       fetchTimeoutMillis: fetchTimeoutMillis,
       retryFetchOnFailure: retryFetchOnFailure,
       automaticExposureTracking: automaticExposureTracking,

--- a/lib/src/experiment_config.dart
+++ b/lib/src/experiment_config.dart
@@ -93,8 +93,10 @@ class ExperimentConfig {
 
   /// Whether [serverUrl] was explicitly provided by the caller.
   ///
-  /// When `false`, the default URL is intentionally withheld from the native
-  /// bridge so the native SDK applies its own [serverZone] -> host routing.
+  /// `true` only when a non-empty value was passed; a `null` or blank value is
+  /// treated as "not set". When `false`, the default URL is intentionally
+  /// withheld from the native bridge so the native SDK applies its own
+  /// [serverZone] -> host routing.
   /// Forwarding the Dart default (which lacks a trailing slash) would
   /// otherwise defeat the native EU override and silently route EU traffic to
   /// the US host.
@@ -152,11 +154,14 @@ class ExperimentConfig {
         ExperimentConfigDefaults.automaticFetchOnAmplitudeIdentityChange,
     this.trackingProvider,
     this.userProvider,
-  }) : serverUrl = serverUrl ?? ExperimentConfigDefaults.serverUrl,
-       flagsServerUrl =
-           flagsServerUrl ?? ExperimentConfigDefaults.flagsServerUrl,
-       _serverUrlExplicitlySet = serverUrl != null,
-       _flagsServerUrlExplicitlySet = flagsServerUrl != null;
+  }) : serverUrl = (serverUrl?.isNotEmpty ?? false)
+           ? serverUrl!
+           : ExperimentConfigDefaults.serverUrl,
+       flagsServerUrl = (flagsServerUrl?.isNotEmpty ?? false)
+           ? flagsServerUrl!
+           : ExperimentConfigDefaults.flagsServerUrl,
+       _serverUrlExplicitlySet = serverUrl?.isNotEmpty ?? false,
+       _flagsServerUrlExplicitlySet = flagsServerUrl?.isNotEmpty ?? false;
 
   pigeon.ExperimentConfigData get pigeonConfig {
     return pigeon.ExperimentConfigData(

--- a/lib/src/web/codec/config_codec.dart
+++ b/lib/src/web/codec/config_codec.dart
@@ -25,6 +25,10 @@ class ConfigCodec {
       'fetchTimeoutMillis': config.fetchTimeoutMillis,
     };
 
+    // An empty URL is the sentinel for "left at the Flutter default". Omitting
+    // it lets the JS SDK resolve the host from serverZone, so serverZone == EU
+    // routes to the EU host instead of being short-circuited by a forwarded
+    // default US URL.
     if (config.serverUrl.isNotEmpty) {
       configMap['serverUrl'] = config.serverUrl;
     }

--- a/test/experiment_config_test.dart
+++ b/test/experiment_config_test.dart
@@ -116,5 +116,19 @@ void main() {
         );
       },
     );
+
+    test('a blank URL is treated as not set and not forwarded', () {
+      final config = ExperimentConfig(
+        serverZone: ServerZone.eu,
+        serverUrl: '',
+        flagsServerUrl: '',
+      );
+      // Blank normalizes to the default for reads, and is withheld from the
+      // bridge so native serverZone resolution still applies.
+      expect(config.serverUrl, ExperimentConfigDefaults.serverUrl);
+      expect(config.flagsServerUrl, ExperimentConfigDefaults.flagsServerUrl);
+      expect(config.pigeonConfig.serverUrl, isEmpty);
+      expect(config.pigeonConfig.flagsServerUrl, isEmpty);
+    });
   });
 }

--- a/test/experiment_config_test.dart
+++ b/test/experiment_config_test.dart
@@ -56,5 +56,65 @@ void main() {
       expect(pigeon.fetchTimeoutMillis, 5000);
       expect(pigeon.retryFetchOnFailure, false);
     });
+
+    // Regression tests for serverZone:EU being silently ignored because the
+    // default US server URLs were always forwarded across the platform bridge,
+    // defeating each native SDK's serverZone -> host resolution.
+    test('default config still exposes the documented default URLs', () {
+      final config = ExperimentConfig();
+      expect(config.serverUrl, ExperimentConfigDefaults.serverUrl);
+      expect(config.flagsServerUrl, ExperimentConfigDefaults.flagsServerUrl);
+    });
+
+    test(
+      'default EU config does not forward default URLs so native resolves EU',
+      () {
+        final config = ExperimentConfig(serverZone: ServerZone.eu);
+        final pigeon = config.pigeonConfig;
+        // Empty sentinel => native SDK resolves the EU host from serverZone
+        // (api.lab.eu.amplitude.com / flag.lab.eu.amplitude.com) instead of
+        // being overridden by the forwarded US default.
+        expect(pigeon.serverUrl, isEmpty);
+        expect(pigeon.flagsServerUrl, isEmpty);
+        expect(pigeon.serverUrl, isNot(contains('api.lab.amplitude.com')));
+        expect(
+          pigeon.flagsServerUrl,
+          isNot(contains('flag.lab.amplitude.com')),
+        );
+      },
+    );
+
+    test(
+      'default US config also withholds the default URLs from the bridge',
+      () {
+        final pigeon = ExperimentConfig().pigeonConfig;
+        expect(pigeon.serverUrl, isEmpty);
+        expect(pigeon.flagsServerUrl, isEmpty);
+      },
+    );
+
+    test('explicit URL overrides are forwarded across the bridge', () {
+      final config = ExperimentConfig(
+        serverZone: ServerZone.eu,
+        serverUrl: 'https://proxy.example.com',
+        flagsServerUrl: 'https://flags.proxy.example.com',
+      );
+      final pigeon = config.pigeonConfig;
+      expect(pigeon.serverUrl, 'https://proxy.example.com');
+      expect(pigeon.flagsServerUrl, 'https://flags.proxy.example.com');
+    });
+
+    test(
+      'explicitly passing a URL equal to the default is still forwarded',
+      () {
+        final config = ExperimentConfig(
+          serverUrl: ExperimentConfigDefaults.serverUrl,
+        );
+        expect(
+          config.pigeonConfig.serverUrl,
+          ExperimentConfigDefaults.serverUrl,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Symptom

Setting `serverZone: ServerZone.eu` is silently ignored. EU traffic is sent to
the US host (`https://api.lab.amplitude.com/sdk/v2/vardata`) and returns `401`.

## Root cause

`ExperimentConfig` always forwards `serverUrl` / `flagsServerUrl` across the
platform bridge, even when they are left at the Dart (US) defaults
(`lib/src/experiment_config.dart:143-144`, `lib/src/constants.dart:3-4`, which
have **no** trailing slash):

- **Android** — `ExperimentSdkCodec.kt:76-77` forwards the URLs unconditionally.
  The native Android SDK applies the EU host only when
  `serverUrl == Defaults.SERVER_URL && flagsServerUrl == Defaults.FLAGS_SERVER_URL && serverZone == EU`
  (`DefaultExperimentClient.kt:125-143`). The native defaults carry a trailing
  slash, so the forwarded slash-less Dart default fails the equality check →
  EU override is skipped → US host.
- **Web** — `lib/src/web/codec/config_codec.dart:28-32` forwards any non-empty
  `serverUrl`. The JS client (`experimentClient.ts:122-132`) uses a truthiness
  `||` override, so any forwarded non-empty `serverUrl` short-circuits its
  `serverZone` routing → EU override skipped → US host.
- **iOS** — unaffected: native defaults are also slash-less, so they match the
  forwarded Dart defaults and the EU guard fires.

> Note: just adding a trailing slash to the Dart constants would fix Android but
> NOT Web, so that alone is insufficient.

## The fix

Distinguish an explicit URL override from the default and only forward the URL
when the caller explicitly set it; otherwise forward an empty sentinel so each
native SDK runs its own `serverZone -> host` resolution.

- `lib/src/experiment_config.dart` — `serverUrl` / `flagsServerUrl` constructor
  params are now nullable; internal `_serverUrlExplicitlySet` /
  `_flagsServerUrlExplicitlySet` flags record whether the caller provided a
  value. Public fields and documented defaults are unchanged (default reads
  still return the documented URLs). `pigeonConfig` forwards `''` when not
  explicitly set.
- `android/.../ExperimentSdkCodec.kt` — only call `builder.serverUrl(...)` /
  `builder.flagsServerUrl(...)` for non-empty values.
- `ios/.../ExperimentSdkCodec.swift` — same non-empty guard (keeps iOS working
  and makes its routing consistent).
- `lib/src/web/codec/config_codec.dart` — already skipped empty URLs; clarified
  with a comment (the empty sentinel now flows through correctly).

## iOS

Unaffected and still works. The non-empty guard is a no-op for the previously
forwarded slash-less defaults except that it now lets iOS resolve the EU host
from `serverZone` too, which is the correct behavior.

## Tests

- `test/experiment_config_test.dart` — regression tests asserting the bridged
  config does **not** carry the US default URLs when left at default (so native
  resolves EU), that explicit overrides are still forwarded, and that public
  default reads are unchanged.
- `android/.../ExperimentSdkCodecTest.kt` — asserts an empty (default) URL with
  `serverZone == EU` leaves the native config identical to one built without an
  explicit URL (so the native client applies the EU host
  `api.lab.eu.amplitude.com` / `flag.lab.eu.amplitude.com`), and that explicit
  URLs are forwarded.
- `README.md` — documents that `serverZone: ServerZone.eu` alone routes to the
  EU hosts; `serverUrl` / `flagsServerUrl` are only for custom proxies.

`dart format` + `flutter analyze` clean (no new issues) and `flutter test`
(39 tests) passes locally.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how config crosses the Flutter bridge for all platforms and affects which Experiment API hosts are used; behavior is well covered by regression tests but misclassification of “explicit” URLs could still misroute traffic.
> 
> **Overview**
> Fixes **`serverZone: ServerZone.eu`** being ignored on Android and Web because the Dart layer always forwarded the default US **`serverUrl`** / **`flagsServerUrl`**, which overrode each platform SDK’s **`serverZone` → host** logic (EU traffic could hit US endpoints and fail with 401).
> 
> **`ExperimentConfig`** now treats nullable **`serverUrl`** / **`flagsServerUrl`** as optional: only non-empty caller values count as explicit overrides. When URLs are left at defaults, **`pigeonConfig`** sends an **empty sentinel** instead of the documented US URLs, while public getters still return the same documented defaults.
> 
> **Android** and **iOS** codecs only call **`builder.serverUrl`** / **`flagsServerUrl`** when the bridged value is non-empty. **Web** **`ConfigCodec`** continues to omit empty URLs (comment clarified). **README** adds an EU data residency section; **Dart**, **Android**, and **iOS** tests cover sentinel behavior, explicit proxy URLs, and EU **`serverZone`** without forwarded defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7f8af2cc620d3cf39d5664720276c03263c3b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->