### PR TITLE
fix: update release-please path for relocated ios codec

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,7 @@ release-please updates these files via `x-release-please-version` annotations:
 | `pubspec.yaml` | `version:` field |
 | `lib/src/web/codec/user_codec.dart` | `_flutterLibraryVersion` constant |
 | `android/.../ExperimentSdkCodec.kt` | `FLUTTER_LIBRARY_VERSION` constant |
-| `ios/Classes/ExperimentSdkCodec.swift` | `flutterLibraryVersion` constant |
+| `ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift` | `flutterLibraryVersion` constant |
 | `ios/amplitude_experiment.podspec` | `s.version` field |
 | `android/build.gradle` | `version` property |
 | `README.md` | Installation version in `pubspec.yaml` snippet |

--- a/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
+++ b/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
@@ -6,7 +6,7 @@ import Foundation
  * Amplitude Experiment SDK types. Mirrors the Android ExperimentSdkCodec.kt.
  */
 enum ExperimentSdkCodec {
-    private static let flutterLibraryVersion = "0.1.0-beta.2" // x-release-please-version
+    private static let flutterLibraryVersion = "0.1.0-beta.3" // x-release-please-version
     private static let iosLibraryVersion = "1.19.0"
     static let flutterLibrary =
         "experiment-flutter-client/\(flutterLibraryVersion)" +

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
         { "type": "generic", "path": "pubspec.yaml" },
         { "type": "generic", "path": "lib/src/web/codec/user_codec.dart" },
         { "type": "generic", "path": "android/src/main/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodec.kt" },
-        { "type": "generic", "path": "ios/Classes/ExperimentSdkCodec.swift" },
+        { "type": "generic", "path": "ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift" },
         { "type": "generic", "path": "ios/amplitude_experiment.podspec" },
         { "type": "generic", "path": "android/build.gradle" },
         { "type": "generic", "path": "README.md" }


### PR DESCRIPTION
### Summary

The SPM restructure (#19) moved `ExperimentSdkCodec.swift` from `ios/Classes/` to `ios/amplitude_experiment/Sources/amplitude_experiment/`, but the release-please `extra-files` entry still pointed at the old path. release-please skips missing paths silently, so the iOS `flutterLibraryVersion` constant was left at `0.1.0-beta.2` during the `0.1.0-beta.3` release — iOS clients report a stale SDK version in the analytics library header while Android, Web, and the podspec all report `beta.3`.

This PR:
- Points the release-please config at the relocated Swift file so future releases bump it again.
- Realigns the constant to `0.1.0-beta.3` to match the released version.
- Updates the version-tracked files table in `RELEASING.md`.

No runtime behavior change beyond the corrected version string. Verified all seven `extra-files` paths in `release-please-config.json` resolve and all `x-release-please-version` annotated constants agree on `0.1.0-beta.3`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-flutter-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<details>
<summary>AI Prompt</summary>

Evaluate this repo and present a plan to move this Flutter SDK from beta to full 1.0.0 release — then cut a PR for Phase 1 (fix the stale release-please iOS codec path and version constant).

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and a client library version string only; no functional experiment or networking logic changes.
> 
> **Overview**
> After the SPM move, **release-please** still targeted `ios/Classes/ExperimentSdkCodec.swift`, so it never updated the iOS `flutterLibraryVersion` on the `0.1.0-beta.3` release. iOS analytics headers stayed on **beta.2** while other platforms reported **beta.3**.
> 
> This PR **retargets** the `extra-files` entry in `release-please-config.json` to `ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift`, **sets** `flutterLibraryVersion` to `0.1.0-beta.3`, and **updates** the version-tracked files table in `RELEASING.md` to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b50a353acbfcb50ec3ae9fa1ddf5d7a12faff984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->