### PR TITLE
feat: update native experiment SDKs to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flutter pub get
 The Flutter Experiment SDK uses Dart's JavaScript interoperability to enable the [Experiment JavaScript SDK](/docs/sdks/experiment-sdks/experiment-javascript) for Flutter Web. This requires that you make the SDK available within the global JavaScript scope. Add the following script tag to `web/index.html` in your Flutter project:
 
 ```html
-<script src="https://unpkg.com/@amplitude/experiment-js-client@1.20.1/dist/experiment.umd.js"></script>
+<script src="https://unpkg.com/@amplitude/experiment-js-client@1.21.3/dist/experiment.umd.js"></script>
 ```
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
 
 dependencies {
     // 1. Client Library
-    implementation("com.amplitude:experiment-android-client:1.15.0")
+    implementation("com.amplitude:experiment-android-client:1.16.1")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.11.0")

--- a/android/src/main/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodec.kt
+++ b/android/src/main/kotlin/com/amplitude/experiment/flutter/ExperimentSdkCodec.kt
@@ -15,7 +15,7 @@ import com.amplitude.experiment.FetchOptions as SdkFetchOptions
 import com.amplitude.experiment.flutter.FetchOptions as FlutterFetchOptions
 
 private const val FLUTTER_LIBRARY_VERSION = "0.1.0-beta.3" // x-release-please-version
-private const val ANDROID_LIBRARY_VERSION = "1.15.0"
+private const val ANDROID_LIBRARY_VERSION = "1.16.1"
 internal const val FLUTTER_LIBRARY =
     "experiment-flutter-client/$FLUTTER_LIBRARY_VERSION" +
     "_experiment-android-client/$ANDROID_LIBRARY_VERSION"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - amplitude_experiment (0.1.0-beta.3):
-    - AmplitudeExperiment (= 1.19.0)
+    - AmplitudeExperiment (< 2.0.0, >= 1.20.2)
     - Flutter
   - amplitude_flutter (4.4.0):
     - AmplitudeSwift (~> 1.17.5)
     - Flutter
     - FlutterMacOS
   - AmplitudeCore (1.4.8)
-  - AmplitudeExperiment (1.19.0):
+  - AmplitudeExperiment (1.20.2):
     - AmplitudeCore (< 2.0.0, >= 1.0.12)
     - AnalyticsConnector (~> 1.3)
   - AmplitudeSwift (1.17.5):
@@ -42,10 +42,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  amplitude_experiment: 8aa8ae283bf9e5993aeba51842710a25b5351d89
+  amplitude_experiment: 96698707a68618bfd88062bc4f9eb7b10f749281
   amplitude_flutter: a430a891abbd9e486f53d2ab499af9ead0bb8047
   AmplitudeCore: d0952b5b193f6926777bcaf73ad2bea47a7706da
-  AmplitudeExperiment: 25356f3ac32a9bfb5f1fdeacb15363b0f8e01985
+  AmplitudeExperiment: ac0b773132736844ab029edd39112b27d6ea740b
   AmplitudeSwift: 89f675b8b81a2710ef244324d2083641ffb702b6
   AnalyticsConnector: b6961a64f7a15207d7cc8a8529e64cccc482c066
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -52,7 +52,7 @@
   </script>
 
   
-  <script src="https://unpkg.com/@amplitude/experiment-js-client@1.20.1/dist/experiment.umd.js"></script>
+  <script src="https://unpkg.com/@amplitude/experiment-js-client@1.21.3/dist/experiment.umd.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/ios/amplitude_experiment.podspec
+++ b/ios/amplitude_experiment.podspec
@@ -20,7 +20,7 @@ The official Amplitude Experiment Flutter SDK for evaluating feature flags and r
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
-  s.dependency 'AmplitudeExperiment', '1.19.0'
+  s.dependency 'AmplitudeExperiment', '>= 1.20.2', '< 2.0.0'
 
   s.resource_bundles = {'amplitude_experiment_privacy' => ['amplitude_experiment/Sources/amplitude_experiment/PrivacyInfo.xcprivacy']}
 end

--- a/ios/amplitude_experiment/Package.swift
+++ b/ios/amplitude_experiment/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/amplitude/experiment-ios-client.git",
-            from: "1.19.0"
+            from: "1.20.2"
         ),
     ],
     targets: [

--- a/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
+++ b/ios/amplitude_experiment/Sources/amplitude_experiment/ExperimentSdkCodec.swift
@@ -7,7 +7,7 @@ import Foundation
  */
 enum ExperimentSdkCodec {
     private static let flutterLibraryVersion = "0.1.0-beta.3" // x-release-please-version
-    private static let iosLibraryVersion = "1.19.0"
+    private static let iosLibraryVersion = "1.20.2"
     static let flutterLibrary =
         "experiment-flutter-client/\(flutterLibraryVersion)" +
         "_experiment-ios-client/\(iosLibraryVersion)"


### PR DESCRIPTION
### Summary

Phase 3 (part 1) of the 1.0.0 graduation plan: bring the wrapped native SDKs up to their latest releases so 1.0.0 doesn't ship against stale engines.

- **Android** `experiment-android-client` 1.15.0 → 1.16.1 — picks up the exposure-dedup reset on identity change (amplitude/experiment-android-client#77) and the evaluation-core 2.3.0 engine swap.
- **iOS** `experiment-ios-client` 1.19.0 → 1.20.2 — picks up `logLevel`/`loggerProvider`, public `getUserProperties()`, and multi-value array property targeting. The podspec previously pinned **exactly** `1.19.0` while `Package.swift` used `from:` (up-to-next-major) — consumers on CocoaPods couldn't receive native fixes without a plugin release, and the two manifests disagreed. The podspec now uses `'>= 1.20.2', '< 2.0.0'` to match SPM semantics.
- **Web** script tag `@amplitude/experiment-js-client` 1.20.1 → 1.21.3 in the README and web example.

The `iosLibraryVersion`/`ANDROID_LIBRARY_VERSION` constants reported in analytics library headers are updated to match. With ranged iOS resolution these constants document the version the wrapper was validated against, which may trail the resolved version — same convention as before, now stated explicitly.

Verified: Android plugin unit tests pass against 1.16.1; iOS RunnerTests pass against 1.20.2 via the pods path; example `Podfile.lock` refreshed accordingly.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-flutter-client/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<details>
<summary>AI Prompt</summary>

From the beta-to-1.0.0 graduation plan: continue with Phase 3 — bump native SDK dependencies (Android 1.16.1, iOS 1.20.2, web 1.21.3) and run the API parity sweep against the sibling SDKs.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flag evaluation and exposure behavior via native SDK upgrades (including Android exposure-dedup on identity change and a looser iOS CocoaPods range), though the Dart/Pigeon surface is unchanged.
> 
> **Overview**
> Updates the Flutter plugin’s **wrapped native Experiment engines** ahead of 1.0.0: Android `experiment-android-client` **1.15.0 → 1.16.1**, iOS **1.19.0 → 1.20.2** (SPM `from:` and refreshed example `Podfile.lock`), and Web `@amplitude/experiment-js-client` **1.20.1 → 1.21.3** in the README and example `web/index.html`.
> 
> On iOS, the **CocoaPods podspec** no longer pins an exact `AmplitudeExperiment` version; it now uses **`>= 1.20.2`, `< 2.0.0`**, aligning CocoaPods with SPM’s up-to-next-major behavior so patch/minor native fixes can resolve without a new plugin release. **`iosLibraryVersion` / `ANDROID_LIBRARY_VERSION`** in the native codecs are bumped to match the versions the wrapper was validated against for analytics library headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6404d8bcdf8e5ee8a331859cb299a4d6145f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->